### PR TITLE
再起動するたびにNPCが重複してしまうバグを修正

### DIFF
--- a/Events.sk
+++ b/Events.sk
@@ -14,7 +14,6 @@ on load:
     initMap()
     initTeam()
     oreReviveAsyncHandler()
-    initNPCs()
     portalConditionAsyncHandler()
     enchantmentGuiAsyncHandler()
     enchantmentAutoSellPendingApplyHandler()
@@ -25,6 +24,9 @@ on load:
     profileTabListNameHandler()
     pickupPeriodicCheckHandlerInit()
     pickupPeriodicAnnounceHandlerInit()
+
+    wait 1 ticks
+    initNPCs()
 
 every second:
     loop all players:


### PR DESCRIPTION
【原因】SkriptのOn loadとCitizenのNPC読み込みタイミングが前後していることにより発生

【対処】処理実行のタイミングを調整することにより解決